### PR TITLE
fix(sandbox): guard empty array expansions under set -u

### DIFF
--- a/ralph
+++ b/ralph
@@ -371,8 +371,8 @@ cmd_sandbox() {
     local up_args=(
         "--workspace-folder" "$PWD"
         "--config" "$config"
-        "${mount_flags[@]}"
-        "${ssh_env[@]}"
+        ${mount_flags[@]+"${mount_flags[@]}"}
+        ${ssh_env[@]+"${ssh_env[@]}"}
     )
     if $rebuild; then
         up_args+=("--remove-existing-container" "--build-no-cache")
@@ -385,7 +385,7 @@ cmd_sandbox() {
     devcontainer exec \
         --workspace-folder "$PWD" \
         --config "$config" \
-        "${ssh_env[@]}" \
+        ${ssh_env[@]+"${ssh_env[@]}"} \
         zsh
 }
 


### PR DESCRIPTION
## Summary
- Fix `line 376: ssh_env[@]: unbound variable` when running `SSH_AUTH_SOCK="" ralph sandbox` with no API keys set
- Root cause: under `set -u`, expanding an empty array with `"${arr[@]}"` triggers an unbound variable error on older Bash (e.g. macOS's system Bash 3.2)
- Use `${arr[@]+"${arr[@]}"}` to safely expand to nothing when the array is empty; also applied the same guard to `mount_flags`

## Test plan
- [ ] `SSH_AUTH_SOCK="" ralph sandbox` starts without the unbound variable error
- [ ] `ralph sandbox` still works in the normal case with `SSH_AUTH_SOCK` set
- [ ] `bats test/` passes
- [ ] `shellcheck ralph` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)