### PR TITLE
fix(sandbox): handle SSH_AUTH_SOCK on macOS VM-based Docker runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,3 +234,26 @@ Install it with npm:
 ```bash
 npm install -g @devcontainers/cli
 ```
+
+**`sandbox` fails with `invalid mount config for type "bind": ... operation not supported`**
+
+Ralph bind-mounts `$SSH_AUTH_SOCK` into the container so git operations can reuse your host's ssh-agent. This fails when the socket lives at a path the Docker runtime's VM cannot bind-mount — either because the path is outside the VM's shared filesystem, or because the socket is a kernel-managed endpoint (e.g. a launchd-created socket on macOS) that doesn't survive the virtfs passthrough.
+
+The symptom is a `docker run` error naming the SSH agent path, for example:
+
+```
+invalid mount config for type "bind": stat /private/tmp/com.apple.launchd.XXXXXX/Listeners: operation not supported
+```
+
+When this happens, depends on your setup:
+
+- **macOS + Colima** — affected. Colima runs Docker inside a Lima VM that only mounts `$HOME` by default, and macOS's default `$SSH_AUTH_SOCK` points at a launchd socket under `/private/tmp/com.apple.launchd.*` which is neither mounted nor bind-mountable.
+- **macOS + Docker Desktop** — not typically affected. Docker Desktop intercepts `$SSH_AUTH_SOCK` and provides a magic `/run/host-services/ssh-auth.sock` passthrough.
+- **macOS + Rancher Desktop / OrbStack / other Lima-based runtimes** — likely affected for the same reason as Colima.
+- **Linux** — not affected. Docker runs natively on the host filesystem.
+
+Workaround: run ralph with an empty `SSH_AUTH_SOCK` so the mount is skipped. Git inside the container will fall back to the read-only `~/.ssh` bind mount (fine for key-based auth without a passphrase):
+
+```bash
+SSH_AUTH_SOCK="" ralph sandbox
+```

--- a/ralph
+++ b/ralph
@@ -330,7 +330,7 @@ cmd_sandbox() {
         "--workspace-folder" "$PWD"
         "--config" "$config"
         "${mount_flags[@]}"
-        "${ssh_env[@]}"
+        ${ssh_env[@]+"${ssh_env[@]}"}
     )
     if $rebuild; then
         up_args+=("--remove-existing-container" "--build-no-cache")
@@ -343,7 +343,7 @@ cmd_sandbox() {
     devcontainer exec \
         --workspace-folder "$PWD" \
         --config "$config" \
-        "${ssh_env[@]}" \
+        ${ssh_env[@]+"${ssh_env[@]}"} \
         zsh
 }
 


### PR DESCRIPTION
## Summary

- Fix a bash 3.2 regression where `ralph sandbox` aborts with `ssh_env[@]: unbound variable` when `SSH_AUTH_SOCK` is unset or cleared and no API-key env vars are exported. Caused by empty-array expansion under `set -u` — guarded with the `${arr[@]+"${arr[@]}"}` pattern (no-op on bash 4+).
- Add a Troubleshooting section to the README explaining when users need to pass `SSH_AUTH_SOCK=""` and why: the host socket path is either outside the Docker VM's shared filesystem or is a kernel-managed endpoint (e.g. launchd sockets on macOS) that cannot traverse the virtfs passthrough. Calls out which runtimes are affected (Colima, other Lima-based setups) vs not (Docker Desktop, Linux).

## Context

Hit while running `ralph sandbox` on macOS + Colima. The initial failure was:

```
invalid mount config for type "bind": stat /private/tmp/com.apple.launchd.XXXXXX/Listeners: operation not supported
```

Working around it with `SSH_AUTH_SOCK="" ralph sandbox` surfaced the second bug — the empty-array expansion — which this PR also fixes.

## Test plan

- [x] `ralph sandbox` fails cleanly on macOS + Colima with the documented error (baseline reproduced)
- [x] `SSH_AUTH_SOCK="" ralph sandbox` starts the container successfully with the fix applied
- [ ] Verify on Docker Desktop (macOS) that the default path still works without the env workaround
- [ ] Verify on Linux that the default path still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)