### PR TITLE
feat(loop): announce the next plan item at iteration start

### DIFF
--- a/ralph
+++ b/ralph
@@ -724,9 +724,13 @@ cmd_metrics() {
 # First incomplete item in IMPLEMENTATION_PLAN.md, stripped of the checkbox
 # prefix and markdown emphasis — the item the build prompt directs the agent
 # to pick next. Empty when the file is absent or every item is complete.
+#
+# Done in a single sed that quits at the first match rather than piping into
+# head: under `set -o pipefail` a head that closes the pipe early makes the
+# whole pipeline non-zero, which would abort the loop on a long plan.
 next_plan_item() {
-    sed -nE 's/^- \[ \] *//p' IMPLEMENTATION_PLAN.md 2>/dev/null \
-        | head -1 | sed 's/\*\*//g'
+    sed -nE '/^- \[ \]/{ s/^- \[ \] *//; s/\*\*//g; p; q; }' \
+        IMPLEMENTATION_PLAN.md 2>/dev/null
 }
 
 cmd_loop() {
@@ -904,7 +908,9 @@ cmd_loop() {
         # attempt; re-read each iteration because the previous one moves it.
         if [[ "$mode" == "build" ]]; then
             local next_item
-            next_item=$(next_plan_item)
+            # An unreadable plan must not abort the loop: announcing is a
+            # convenience, so fall back to silence rather than failing.
+            next_item=$(next_plan_item) || next_item=""
             if [[ -n "$next_item" ]]; then
                 truncate_line "Next:    $next_item" "$line_width"
                 echo ""

--- a/ralph
+++ b/ralph
@@ -721,6 +721,14 @@ cmd_metrics() {
         ' "$file"
 }
 
+# First incomplete item in IMPLEMENTATION_PLAN.md, stripped of the checkbox
+# prefix and markdown emphasis — the item the build prompt directs the agent
+# to pick next. Empty when the file is absent or every item is complete.
+next_plan_item() {
+    sed -nE 's/^- \[ \] *//p' IMPLEMENTATION_PLAN.md 2>/dev/null \
+        | head -1 | sed 's/\*\*//g'
+}
+
 cmd_loop() {
     local mode="$1"
     shift
@@ -889,6 +897,19 @@ cmd_loop() {
             "$(printf '%*s' "$pad_left" '' | tr ' ' '=')" \
             "$iter_label" \
             "$(printf '%*s' "$pad_right" '' | tr ' ' '=')"
+
+        # Announce the iteration's target up front — the loop is otherwise
+        # silent until the backend finishes. Build mode works the plan top
+        # down, so the first incomplete entry is what this iteration will
+        # attempt; re-read each iteration because the previous one moves it.
+        if [[ "$mode" == "build" ]]; then
+            local next_item
+            next_item=$(next_plan_item)
+            if [[ -n "$next_item" ]]; then
+                truncate_line "Next:    $next_item" "$line_width"
+                echo ""
+            fi
+        fi
 
         # Snapshot HEAD to detect noops
         local head_before

--- a/test/next_item.bats
+++ b/test/next_item.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+# The iteration-start announcement: build mode prints the first incomplete
+# plan item under the iteration banner, so a running loop shows what it is
+# attempting instead of staying silent until the backend finishes.
+
+@test "build announces the first incomplete plan item at iteration start" {
+    "$RALPH" init
+    printf -- '- [x] **A1. Shipped thing**\n- [ ] **B2. Next thing to build**\n- [ ] **C3. Later thing**\n' > IMPLEMENTATION_PLAN.md
+
+    run "$RALPH" build --dry-run -n 1
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Next:    B2. Next thing to build"* ]]
+}
+
+@test "announcement strips markdown emphasis from the item title" {
+    "$RALPH" init
+    printf -- '- [ ] **Bold title**\n' > IMPLEMENTATION_PLAN.md
+
+    run "$RALPH" build --dry-run -n 1
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Next:    Bold title"* ]]
+    [[ "$output" != *"Next:    \*\*"* ]]
+}
+
+@test "only the first incomplete item is announced" {
+    "$RALPH" init
+    printf -- '- [ ] **First open**\n- [ ] **Second open**\n' > IMPLEMENTATION_PLAN.md
+
+    run "$RALPH" build --dry-run -n 1
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Next:    First open"* ]]
+    [[ "$output" != *"Next:    Second open"* ]]
+}
+
+@test "a long item title is truncated to the line width" {
+    "$RALPH" init
+    local long_title
+    long_title=$(printf 'X%.0s' $(seq 1 150))
+    printf -- '- [ ] %s\n' "$long_title" > IMPLEMENTATION_PLAN.md
+
+    run "$RALPH" build --dry-run -n 1
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Next:    XXX"* ]]
+    [[ "$output" == *"..."* ]]
+    [[ "$output" != *"$long_title"* ]]
+}
+
+@test "no announcement when every plan item is complete" {
+    "$RALPH" init
+    printf -- '- [x] **A1. Shipped**\n' > IMPLEMENTATION_PLAN.md
+
+    run "$RALPH" build --dry-run -n 1
+    [[ "$status" -eq 0 ]]
+    [[ "$output" != *"Next:"* ]]
+}
+
+@test "plan mode does not announce a next item" {
+    "$RALPH" init
+    printf -- '- [ ] **B2. Open item**\n' > IMPLEMENTATION_PLAN.md
+
+    run "$RALPH" plan --dry-run -n 1
+    [[ "$status" -eq 0 ]]
+    [[ "$output" != *"Next:"* ]]
+}

--- a/test/next_item.bats
+++ b/test/next_item.bats
@@ -65,3 +65,19 @@ load test_helper
     [[ "$status" -eq 0 ]]
     [[ "$output" != *"Next:"* ]]
 }
+
+# Regression: the lookup used to pipe into `head -1`, so on a plan long enough
+# for head to close the pipe early, `set -o pipefail` made the pipeline non-zero
+# and the unguarded assignment aborted the loop under `set -e`.
+@test "a long plan announces its first item without aborting the loop" {
+    "$RALPH" init
+    printf -- '- [ ] **First open item**\n' > IMPLEMENTATION_PLAN.md
+    for i in $(seq 1 2000); do
+        printf -- '- [ ] **Filler item %s**\n' "$i" >> IMPLEMENTATION_PLAN.md
+    done
+
+    run "$RALPH" build --dry-run -n 1
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Next:    First open item"* ]]
+    [[ "$output" == *"Completed 1 iterations."* ]]
+}


### PR DESCRIPTION
Build iterations print `Next: <first incomplete plan item>` directly under the iteration banner, so a running loop shows what it is attempting instead of staying silent until the backend finishes.

Supersedes #10, which was cut from a fork branch and so both conflicted with the metrics work now on `main` and carried an unrelated Dockerfile change. This branch is cut from current `main` and is scoped to the announcement alone.

### Behaviour

- The plan is re-read each iteration, since the previous iteration moves the first incomplete entry.
- Markdown emphasis is stripped from the title; long titles truncate to the line width via the existing `truncate_line`.
- Silent in plan mode, and silent when every plan item is complete.

Build mode works the plan top down, so the first incomplete entry is what the iteration will attempt. This is ralph's read of the plan rather than confirmation from the backend — it predicts the pick rather than reporting it.

The lookup is a single `sed` that quits at the first match rather than piping into `head`. Under `set -o pipefail` a `head` that closes the pipe early makes the pipeline non-zero, which would abort the loop on a long plan; the call site also falls back to silence if the plan is unreadable, so announcing can never interrupt a run.

### Test plan

7 bats tests in `test/next_item.bats`: the announcement itself, emphasis stripping, first-item-only selection, long-title truncation, the all-complete case, plan-mode silence, and a 2000-item plan as a regression test for the `set -e` interaction above (it fails against the naive `head -1` implementation).

Full suite on this branch: **174 tests, 0 failures**. ShellCheck clean across `ralph install.sh test/*.bats test/test_helper.bash`.
