### PR TITLE
docs(prompts): cut per-iteration context cost

### DIFF
--- a/prompts/build.md
+++ b/prompts/build.md
@@ -29,6 +29,7 @@ Select the single highest-priority incomplete item from `IMPLEMENTATION_PLAN.md`
 - Search the codebase before writing new code; the functionality may already exist
 - If specs are inconsistent, use an **Opus** reasoning subagent with ultrathink to update the specs before implementing
 - You may add logging to debug issues
+- **If the item outgrows the iteration, split it instead of grinding.** When the item is still incomplete after roughly 60 turns of work, or accumulated output is crowding your context: bring what you have built to green, insert new fine-grained item(s) for the remainder **directly after the current item** (splitting is the one case where inserting beats appending — the remainder keeps the original's priority), then mark the current item done with a completion note naming the split-out remainder, and proceed to Phase 4 as normal. A fresh iteration on the remainder is faster and cheaper than finishing at the context ceiling.
 
 ## Phase 3: Verify
 
@@ -64,5 +65,5 @@ Once tests pass:
 - **Implement completely.** Placeholders and stubs waste effort redoing the same work.
 - **Single sources of truth.** Don't duplicate information across files.
 - **Document the why** — in tests, commits, and documentation, capture importance and reasoning.
-- **Keep `IMPLEMENTATION_PLAN.md` current** — mark items done and append new ones, but **never delete**; future iterations depend on it to avoid duplicating effort.
+- **Keep `IMPLEMENTATION_PLAN.md` current** — mark items done and append new ones, but **never delete**; future iterations depend on it to avoid duplicating effort. (Remainders of a split item are inserted after their parent rather than appended, so they keep their priority.)
 - For bugs you notice outside the current item, document them as new items in `IMPLEMENTATION_PLAN.md` instead of fixing them inline — a future iteration will pick them up.

--- a/prompts/build.md
+++ b/prompts/build.md
@@ -34,6 +34,8 @@ Select the single highest-priority incomplete item from `IMPLEMENTATION_PLAN.md`
 
 Run the project's test suite to validate your changes.
 
+- **Keep test output out of your context.** Run suites through a quiet reporter and/or pipe to `tail -30` (e.g. `npm test 2>&1 | tail -30`); read the full log only when diagnosing a failure it names. Accumulated test output is what fills the context window mid-item.
+- **Don't re-run the full suite after every change.** While iterating, run only the narrowest tests covering the code you touched; run the full suite once, when you believe the item is complete.
 - If tests fail, use an **Opus** reasoning subagent to reason about the root cause before attempting fixes
 - If tests unrelated to your work fail, resolve them as part of this increment
 - If functionality is missing, add it per the specifications

--- a/prompts/build.md
+++ b/prompts/build.md
@@ -44,6 +44,7 @@ Run the project's test suite to validate your changes.
 Once tests pass:
 
 1. Update `IMPLEMENTATION_PLAN.md` — mark the completed item as done (`- [x]`); **never delete it**. The plan is an append-only ledger: completed items stay as a record of what shipped. You may **append** new items if this iteration surfaced follow-up work, but do not remove or rewrite existing ones.
+   - **Completion notes are capped at 3 lines**, appended to the item: what shipped, test counts, and any deviation with its tracking reference (e.g. an `OPEN_QUESTIONS.md` id). The plan is a work queue that every future iteration re-reads in full — the narrative, evidence and reasoning belong in `PROGRESS.md` (step 2), not here.
 2. Append an entry to `PROGRESS.md` following the template defined in its header (append-only — never edit previous entries)
 3. Commit the changes by invoking the **`/commit` skill**. Do NOT compose commits manually. Rules for this iteration:
    - **Atomic commits**: if the working tree contains separable concerns **within this item** (e.g. a refactor *and* the feature it enables, or test additions that stand on their own), produce **multiple commits in one skill invocation** — one per concern — instead of a single grab-bag commit.


### PR DESCRIPTION
Three changes to `prompts/build.md` that cut the context a build iteration carries.

- **Completion notes capped at 3 lines** — what shipped, test counts, and any deviation with its tracking reference. `IMPLEMENTATION_PLAN.md` is a work queue every future iteration re-reads in full, so narrative, evidence and reasoning go to `PROGRESS.md` instead.
- **Quiet test output** — run suites through a quiet reporter and/or `tail -30`, reading the full log only when diagnosing a named failure. Also stops mid-item full-suite re-runs: narrowest relevant tests while iterating, full suite once when the item is believed complete.
- **Split items at ~60 turns** — when an item is still incomplete after roughly 60 turns, or output is crowding context, bring what exists to green, insert the remainder as new fine-grained item(s) directly after the current one, and finish the iteration. Splitting is the one case where inserting beats appending: the remainder keeps the original's priority.

### Motivation

From profiling an e2e harness run:

- Cost correlates **0.99** with cache reads — what the loop re-reads each iteration dominates, not what it writes.
- Completed-item narratives were **82%** of a 399KB plan, re-read in full every iteration.
- Iterations exceeding 120 turns were **37%** of spend.

Each change targets one: the note cap shrinks what the plan re-reads, quiet output slows context growth within an item, and the split rule caps the long tail.

See the individual commit messages for detail.

### Test plan

Documentation only — `prompts/build.md` is the sole file touched, no code paths affected.
