### PR TITLE
ci: allow the workflow to be triggered manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Manual trigger, so CI can be re-run on demand without pushing a commit —
+  # useful for confirming the runner works after an Actions settings change.
+  workflow_dispatch:
 
 jobs:
   shellcheck:


### PR DESCRIPTION
Adds `workflow_dispatch` to the CI workflow so it can be re-run on demand without pushing a commit.

Useful when confirming the runner works after an Actions settings change — particularly on forks, where GitHub gates workflow runs until the fork owner enables them and no amount of pushing will trigger a run until they do.

`workflow_dispatch` only becomes usable once the workflow is on the default branch, so the manual trigger works after merge, not on this PR.

### Test plan

YAML validated — parses clean, triggers resolve to `push`, `pull_request`, `workflow_dispatch`, jobs unchanged (`shellcheck`, `test`). Neither job's steps are modified.
