### PR TITLE
build(sandbox): bump base image to node 24, add buildx plugin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ Ralph is a single Bash script (`ralph`) with these commands:
 ### Sandbox
 
 Uses the `devcontainer` CLI to manage container lifecycle. Key details:
-- Base image: Node.js 20 with Claude Code, gh, git, zsh, jq, ripgrep, SDKMAN
+- Base image: Node.js 24 with Claude Code, gh, git, zsh, jq, ripgrep, SDKMAN
 - Mounts: workspace, `~/.claude`, `~/.gitconfig`, `~/.ssh`, Docker socket, SSH agent, ralph binary
 - Shell history persists via Docker volumes keyed by a hash of the workspace path
 - Runs as `node` user with passwordless sudo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Ralph is a single Bash script (`ralph`) with these commands:
 ### Sandbox
 
 Uses the `devcontainer` CLI to manage container lifecycle. Key details:
-- Base image: Node.js 20 with Claude Code, gh, git, zsh, jq, ripgrep, Bun, uv, SDKMAN
+- Base image: Node.js 24 with Claude Code, gh, git, zsh, jq, ripgrep, Bun, uv, SDKMAN
 - Mounts: workspace, `~/.claude`, `~/.gitconfig`, `~/.ssh`, Docker socket, SSH agent, ralph binary
 - Shell history persists via Docker volumes keyed by a hash of the workspace path
 - Runs as `node` user with passwordless sudo

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ ralph init --prompts                                # also copy prompts for cust
 
 ## Sandbox
 
-The sandbox runs your project inside a devcontainer — an isolated environment with Claude Code, Codex CLI, GitHub Copilot CLI, Node.js 20, Bun, uv, SDKMAN, Docker CLI, and development tools pre-installed. The active backend runs as a non-root user with its backend-specific permission-bypass flag enabled.
+The sandbox runs your project inside a devcontainer — an isolated environment with Claude Code, Codex CLI, GitHub Copilot CLI, Node.js 24, Bun, uv, SDKMAN, Docker CLI, and development tools pre-installed. The active backend runs as a non-root user with its backend-specific permission-bypass flag enabled.
 
 ### Prerequisites
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:24
 
 ARG TZ
 ENV TZ="$TZ"
@@ -35,7 +35,7 @@ RUN install -m 0755 -d /etc/apt/keyrings \
      https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
      > /etc/apt/sources.list.d/docker.list \
   && apt-get update \
-  && apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin \
+  && apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin docker-buildx-plugin \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # git-delta


### PR DESCRIPTION
Bumps the devcontainer base image from `node:20` to `node:24` and installs `docker-buildx-plugin` alongside `docker-ce-cli`, so buildx is available inside the sandbox.

Original change authored by Laurence Jones; the commit retains his authorship.

The second commit updates documentation that the bump made stale — `README.md`, `CLAUDE.md` and `AGENTS.md` all described the base image as Node.js 20.

### Test plan

Full bats suite passes on this branch (**167 tests, 0 failures**) and ShellCheck is clean across `ralph install.sh test/*.bats test/test_helper.bash`.

Note the image change itself isn't covered by the suite — it wants a `ralph sandbox --rebuild` on a machine with the `devcontainer` CLI to confirm the image still builds and that buildx is present. I have not run that.
